### PR TITLE
PR: Assignment2-2 (경지윤)

### DIFF
--- a/src/utils/axios-setting.js
+++ b/src/utils/axios-setting.js
@@ -21,18 +21,66 @@ authAxios.interceptors.request.use((config) => {
 });
 
 authAxios.interceptors.response.use(
-  function (response) {
+  (response) => {
     return response;
   },
-  async function (error) {
+  async (error) => {
     const { response: errorResponse } = error;
+    const { request: errorResquest } = error;
     const errorResp = error.response.data.message;
-    // 인증 에러 발생시
-    if (errorResponse.status === 401 && errorResp === 'Unauthorized') {
-      alert('아이디와 비밀번호를 확인해주세요.');
-      window.location.href = '/';
+    if (errorResponse) {
+      // 인증 에러 발생시
+      if (errorResponse.status === 401 && errorResp === 'Unauthorized') {
+        alert('아이디와 비밀번호를 확인해주세요.');
+        window.location.href = '/';
+      } else {
+        alert('올바른 아이디와 비밀번호를 입력해주세요.');
+      }
+    } else if (errorResquest) {
+      alert(
+        '로그인/회원가입 요청이 거절되었습니다. 네트워크를 확인하거나 다시 시도해주세요',
+      );
     } else {
-      alert(errorResp);
+      alert(`${error.message} : 잘못된 요청입니다. 다시 시도해주세요.`);
+    }
+
+    return Promise.reject(error);
+  },
+);
+
+export const todosAxios = axios.create({
+  baseURL,
+  headers,
+});
+
+todosAxios.interceptors.request.use((config) => {
+  const accessToken = getLocalStorageToken();
+  if (accessToken && config.headers) {
+    config.headers['Authorization'] = `Bearer ${accessToken}`;
+  }
+  return config;
+});
+
+todosAxios.interceptors.response.use(
+  (response) => {
+    return response;
+  },
+  async (error) => {
+    const { response: errorResponse } = error;
+    const { request: errorResquest } = error;
+    const errorResp = error.response.data.message;
+    if (errorResponse) {
+      // 인증 에러 발생시
+      if (errorResponse.status === 401 && errorResp === 'Unauthorized') {
+        alert('로그아웃 되었습니다.다시 로그인 해주세요.');
+        window.location.href = '/';
+      } else {
+        alert('올바른 값을 입력해주세요.');
+      }
+    } else if (errorResquest) {
+      alert('잘못된 요청입니다. 네트워크를 확인하거나 다시 시도해주세요');
+    } else {
+      alert(`${error.message} : 잘못된 요청입니다. 다시 시도해주세요.`);
     }
 
     return Promise.reject(error);


### PR DESCRIPTION
## 🔎 What is this PR?

- axios 미들웨어에 response, reqeust 그리고 나머지 상황에서 발생하는 에러 핸들링입니다.
-  postman 으로 여러가지 api 요청을 테스트해보고 아래와 같은 에러상황을 고려하여 코드 작성했습니다.

```
잘못된 인증일때 (로그인이 안되어있거나 실패할때)
status : 401
message : "Unauthorized"


todo post 시 빈값을 Post 할때 && string 값이 아닐때
 status : 400
message :todo must be a string
message : todo should not be empty

빈값일때 && isComplete 가 boolean 값이 아닐때 && todo 가 string 값이 아닐때
"statusCode": 400,
"message": [
    "todo must be a string",
   "todo should not be empty",
    "isCompleted must be a boolean value",
    "isCompleted should not be empty"
 ],
```

## 🔑 Key Changes
- 코드 컨벤션에 맞춰 콜백 함수를 모두 화살표 함수로 변경했습니다.
- Response, request , 나머지 에러 3가지의 경우를 고려하여 분기처리 하는 코드로 변경했습니다. 
- todoAxios 지만 토큰이 사라졌거나 없는 상태에서 요청하면 401 이 뜨는 것을 확인하고 따로 분기처리해주었습니다. 

``` js
todosAxios.interceptors.response.use(
  (response) => {
    return response;
  },
  async (error) => {
    const { response: errorResponse } = error;
    const { request: errorResquest } = error;
    const errorResp = error.response.data.message;
    if (errorResponse) {
      // 토큰이 없는 상태에서 todo 관련 api 요청시 401 에러 
      if (errorResponse.status === 401 && errorResp === 'Unauthorized') {
        alert('로그아웃 되었습니다.다시 로그인 해주세요.');
        window.location.href = '/';
      } else {
        alert('올바른 값을 입력해주세요.');
      }
    } else if (errorResquest) {
      alert('잘못된 요청입니다. 네트워크를 확인하거나 다시 시도해주세요');
    } else {
      alert(`${error.message} : 잘못된 요청입니다. 다시 시도해주세요.`);
    }

    return Promise.reject(error);
  },
```
- todo post/get/update/delete 등 api 요청시 토큰이 없을때 401 
  - 토큰이 없을일이 거의 없겠지만 인위적으로 로컬스토리지에서 삭제할 경우 등등 혹시 몰라 처리했습니다. 
<img width="995" alt="스크린샷 2022-12-23 오전 1 29 34" src="https://user-images.githubusercontent.com/81758576/209179173-18ce92e1-0842-470f-93dc-aa7637ae1aef.png">


## 🙋🏻‍♀️ To Reviewers

- 에러 멘트가 적절한지 같이 봐주시면 좋겠습니다.
- 401 에러후 `window.location.href = '/';` 코드 말고 다른 대안이 있으면 같이 상의하고싶습니다.
